### PR TITLE
Debug session synchronization error

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -8,7 +8,16 @@ module ApplicationCable
 
     private
       def set_current_user
-        if session = Session.find_by(id: cookies.signed[:session_id])
+        session_id = nil
+        begin
+          session_id = cookies.signed[:session_id]
+        rescue ActiveSupport::MessageVerifier::InvalidSignature, ActiveSupport::MessageEncryptor::InvalidMessage => error
+          Rails.logger.warn("Invalid session cookie on cable connect: #{error.class.name}")
+          cookies.delete(:session_id)
+          return
+        end
+
+        if session = Session.find_by(id: session_id)
           self.current_user = session.user
         end
       end


### PR DESCRIPTION
Add defensive cookie reading to prevent 500 errors from invalid session cookies and improve cross-device session handling.

The 500 error occurred when `cookies.signed[:session_id]` raised `ActiveSupport::MessageVerifier::InvalidSignature` or `ActiveSupport::MessageEncryptor::InvalidMessage` due to a stale or invalid session cookie (e.g., from a different device or rotated `secret_key_base`). This change rescues these exceptions, clears the bad cookie, and makes `terminate_session` nil-safe, allowing the user to re-authenticate instead of encountering a server error.

---
<a href="https://cursor.com/background-agent?bcId=bc-467d40c6-cc9f-46e9-a5ca-8c9b1e65cb1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-467d40c6-cc9f-46e9-a5ca-8c9b1e65cb1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

